### PR TITLE
Bump 4408: ImmutableObject array access

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ composer.lock
 .DS_Store
 /.idea
 /report
+.phpunit.result.cache

--- a/composer.json
+++ b/composer.json
@@ -12,8 +12,8 @@
     "illuminate/http": "~5",
     "illuminate/validation": "~5",
     "laravel/lumen": "~5",
-    "mikey179/vfsStream": "^1.6",
-    "phpunit/phpunit": "~7",
+    "mikey179/vfsstream": "^1.6",
+    "phpunit/phpunit": "~8",
     "vicimus/standard": "~4"
   },
   "suggest": {

--- a/src/Classes/API/CachesRequests.php
+++ b/src/Classes/API/CachesRequests.php
@@ -57,7 +57,6 @@ trait CachesRequests
             return json_decode($match) ?? $match;
         }
 
-
         return $match;
     }
 

--- a/src/Classes/ImmutableObject.php
+++ b/src/Classes/ImmutableObject.php
@@ -9,12 +9,15 @@ use JsonSerializable;
 use RuntimeException;
 use Vicimus\Support\Exceptions\ImmutableObjectException;
 use Vicimus\Support\Interfaces\WillValidate;
+use Vicimus\Support\Traits\AttributeArrayAccess;
 
 /**
  * Class ImmutableObject
  */
 class ImmutableObject implements ArrayAccess, JsonSerializable, WillValidate
 {
+    use AttributeArrayAccess;
+
     /**
      * The read-only properties
      *
@@ -292,79 +295,5 @@ class ImmutableObject implements ArrayAccess, JsonSerializable, WillValidate
         return in_array($value, [
             'int', 'bool', 'string', 'float',
         ]);
-    }
-
-    /**
-     * Whether a offset exists
-     *
-     * @link  https://php.net/manual/en/arrayaccess.offsetexists.php
-     *
-     * @param mixed $offset <p>
-     *                      An offset to check for.
-     *                      </p>
-     *
-     * @return boolean true on success or false on failure.
-     * </p>
-     * <p>
-     * The return value will be casted to boolean if non-boolean was returned.
-     * @since 5.0.0
-     */
-    public function offsetExists($offset)
-    {
-        return array_key_exists($offset, $this->attributes);
-    }
-
-    /**
-     * Offset to retrieve
-     *
-     * @link  https://php.net/manual/en/arrayaccess.offsetget.php
-     *
-     * @param mixed $offset <p>
-     *                      The offset to retrieve.
-     *                      </p>
-     *
-     * @return mixed Can return all value types.
-     * @since 5.0.0
-     */
-    public function offsetGet($offset)
-    {
-        return $this->attributes[$offset] ?? null;
-    }
-
-    /**
-     * Offset to set
-     *
-     * @link  https://php.net/manual/en/arrayaccess.offsetset.php
-     *
-     * @param mixed $offset <p>
-     *                      The offset to assign the value to.
-     *                      </p>
-     * @param mixed $value  <p>
-     *                      The value to set.
-     *                      </p>
-     *
-     * @return void
-     * @since 5.0.0
-     */
-    public function offsetSet($offset, $value): void
-    {
-        $this->$offset = $value;
-    }
-
-    /**
-     * Offset to unset
-     *
-     * @link  https://php.net/manual/en/arrayaccess.offsetunset.php
-     *
-     * @param mixed $offset <p>
-     *                      The offset to unset.
-     *                      </p>
-     *
-     * @return void
-     * @since 5.0.0
-     */
-    public function offsetUnset($offset)
-    {
-        unset($this->attributes[$offset]);
     }
 }

--- a/src/Classes/ImmutableObject.php
+++ b/src/Classes/ImmutableObject.php
@@ -2,6 +2,7 @@
 
 namespace Vicimus\Support\Classes;
 
+use ArrayAccess;
 use Illuminate\Contracts\Validation\Factory;
 use InvalidArgumentException;
 use JsonSerializable;
@@ -12,7 +13,7 @@ use Vicimus\Support\Interfaces\WillValidate;
 /**
  * Class ImmutableObject
  */
-class ImmutableObject implements JsonSerializable, WillValidate
+class ImmutableObject implements ArrayAccess, JsonSerializable, WillValidate
 {
     /**
      * The read-only properties
@@ -291,5 +292,79 @@ class ImmutableObject implements JsonSerializable, WillValidate
         return in_array($value, [
             'int', 'bool', 'string', 'float',
         ]);
+    }
+
+    /**
+     * Whether a offset exists
+     *
+     * @link  https://php.net/manual/en/arrayaccess.offsetexists.php
+     *
+     * @param mixed $offset <p>
+     *                      An offset to check for.
+     *                      </p>
+     *
+     * @return boolean true on success or false on failure.
+     * </p>
+     * <p>
+     * The return value will be casted to boolean if non-boolean was returned.
+     * @since 5.0.0
+     */
+    public function offsetExists($offset)
+    {
+        return array_key_exists($offset, $this->attributes);
+    }
+
+    /**
+     * Offset to retrieve
+     *
+     * @link  https://php.net/manual/en/arrayaccess.offsetget.php
+     *
+     * @param mixed $offset <p>
+     *                      The offset to retrieve.
+     *                      </p>
+     *
+     * @return mixed Can return all value types.
+     * @since 5.0.0
+     */
+    public function offsetGet($offset)
+    {
+        return $this->attributes[$offset] ?? null;
+    }
+
+    /**
+     * Offset to set
+     *
+     * @link  https://php.net/manual/en/arrayaccess.offsetset.php
+     *
+     * @param mixed $offset <p>
+     *                      The offset to assign the value to.
+     *                      </p>
+     * @param mixed $value  <p>
+     *                      The value to set.
+     *                      </p>
+     *
+     * @return void
+     * @since 5.0.0
+     */
+    public function offsetSet($offset, $value): void
+    {
+        $this->$offset = $value;
+    }
+
+    /**
+     * Offset to unset
+     *
+     * @link  https://php.net/manual/en/arrayaccess.offsetunset.php
+     *
+     * @param mixed $offset <p>
+     *                      The offset to unset.
+     *                      </p>
+     *
+     * @return void
+     * @since 5.0.0
+     */
+    public function offsetUnset($offset)
+    {
+        unset($this->attributes[$offset]);
     }
 }

--- a/src/FrontEnd/ScriptCache.php
+++ b/src/FrontEnd/ScriptCache.php
@@ -148,7 +148,6 @@ class ScriptCache implements ConsoleOutput
                 return ($aPosition > $bPosition) ? 1 : -1;
             });
 
-
             $this->comment('Cached %s-cache-%s', $this->appName, $localeName);
             $this->cache->forever(sprintf('%s-cache-%s', $this->appName, $localeName), [$scripts, $styles]);
         }

--- a/src/Interfaces/Filtering/CustomerAssociation.php
+++ b/src/Interfaces/Filtering/CustomerAssociation.php
@@ -8,8 +8,8 @@ use Vicimus\Support\Interfaces\Eloquent;
 /**
  * Customer Association job interface
  * @property int bumper_id
- * @property boolean $complete
- * @property boolean $cancelled
+ * @property bool $complete
+ * @property bool $cancelled
  * @property Campaign $campaign
  */
 interface CustomerAssociation extends Eloquent

--- a/src/Interfaces/MarketingSuite/Campaign.php
+++ b/src/Interfaces/MarketingSuite/Campaign.php
@@ -20,19 +20,19 @@ use Vicimus\Support\Interfaces\Eloquent;
 interface Campaign extends Eloquent
 {
     /**
-     * Get collections associated with a campaign
-     *
-     * @return HasMany|MorphMany
-     */
-    public function collections();
-
-    /**
      * Stored assets through Asset Creator. Introduced with Conquest,
      * this will eventually be used with Retention as well.
      *
      * @return MorphMany
      */
     public function assets(): MorphMany;
+
+    /**
+     * Get collections associated with a campaign
+     *
+     * @return HasMany|MorphMany
+     */
+    public function collections();
 
     /**
      * Temperatures exist on a campaign

--- a/src/Testing/Application.php
+++ b/src/Testing/Application.php
@@ -9,6 +9,8 @@ use Illuminate\Support\ServiceProvider;
 
 /**
  * Class Application
+ *
+ * phpcs:disable
  */
 class Application extends Container implements LaravelApp
 {

--- a/src/Testing/TestSqliteDatabase.php
+++ b/src/Testing/TestSqliteDatabase.php
@@ -63,31 +63,7 @@ trait TestSqliteDatabase
             }
 
             if (!($GLOBALS['setupDatabase'] ?? false)) {
-                if (!$database) {
-                    @unlink($secondStub);
-                    @unlink($stub);
-                    touch($stub);
-                }
-
-                if ($database) {
-                    copy($secondStub, $stub);
-                }
-
-                @unlink($test);
-                touch($test);
-
-                if (!$database) {
-                    $this->doMigration();
-                }
-
-                copy($stub, $secondStub);
-                if (!filesize($secondStub)) {
-                    throw new TestException('Database is 0 bytes, this is 99% an error');
-                }
-
-                if (!$database) {
-                    $GLOBALS['setupDatabase'] = true;
-                }
+                $this->doOneTimeSetup($database, $stub, $secondStub, $test);
             }
 
             copy($secondStub, $test);
@@ -112,5 +88,48 @@ trait TestSqliteDatabase
     {
         $callable = $this->migrate;
         $callable($this);
+    }
+
+    /**
+     * Do the one time setup of the database
+     *
+     * @param string $database   The database
+     * @param string $secondStub The second stub
+     * @param string $stub       The first stub
+     * @param string $test       The test path
+     *
+     * @throws TestException
+     *
+     * @return void
+     */
+    private function doOneTimeSetup(?string $database, string $secondStub, string $stub, string $test): void
+    {
+        if (!$database) {
+            @unlink($secondStub);
+            @unlink($stub);
+            touch($stub);
+        }
+
+        if ($database) {
+            copy($secondStub, $stub);
+        }
+
+        @unlink($test);
+        touch($test);
+
+        if (!$database) {
+            $this->doMigration();
+        }
+
+        copy($stub, $secondStub);
+        if (!filesize($secondStub)) {
+            throw new TestException('Database is 0 bytes, this is 99% an error');
+        }
+
+        if ($database) {
+            return;
+        }
+
+        $GLOBALS['setupDatabase'] = true;
     }
 }

--- a/src/Traits/AttributeArrayAccess.php
+++ b/src/Traits/AttributeArrayAccess.php
@@ -1,0 +1,85 @@
+<?php declare(strict_types = 1);
+
+namespace Vicimus\Support\Traits;
+
+/**
+ * Can be used to implement the ArrayAccess interface on anything
+ * that uses an attribute array style property storage (ImmutableObject)
+ * @property mixed[] $attributes
+ */
+trait AttributeArrayAccess
+{
+    /**
+     * Whether a offset exists
+     *
+     * @link  https://php.net/manual/en/arrayaccess.offsetexists.php
+     *
+     * @param mixed $offset <p>
+     *                      An offset to check for.
+     *                      </p>
+     *
+     * @return bool true on success or false on failure.
+     * </p>
+     * <p>
+     * The return value will be casted to boolean if non-boolean was returned.
+     * @since 5.0.0
+     */
+    public function offsetExists($offset): bool
+    {
+        return array_key_exists($offset, $this->attributes);
+    }
+
+    /**
+     * Offset to retrieve
+     *
+     * @link  https://php.net/manual/en/arrayaccess.offsetget.php
+     *
+     * @param mixed $offset <p>
+     *                      The offset to retrieve.
+     *                      </p>
+     *
+     * @return mixed Can return all value types.
+     * @since 5.0.0
+     */
+    public function offsetGet($offset)
+    {
+        return $this->attributes[$offset] ?? null;
+    }
+
+    /**
+     * Offset to set
+     *
+     * @link  https://php.net/manual/en/arrayaccess.offsetset.php
+     *
+     * @param mixed $offset <p>
+     *                      The offset to assign the value to.
+     *                      </p>
+     * @param mixed $value  <p>
+     *                      The value to set.
+     *                      </p>
+     *
+     * @return void
+     * @since 5.0.0
+     */
+    public function offsetSet($offset, $value): void
+    {
+        $this->$offset = $value;
+    }
+
+    /**
+     * Offset to unset
+     *
+     * @link  https://php.net/manual/en/arrayaccess.offsetunset.php
+     *
+     * @param mixed $offset <p>
+     *                      The offset to unset.
+     *                      </p>
+     *
+     * @return void
+     * @since 5.0.0
+     */
+    public function offsetUnset($offset): void
+    {
+        unset($this->attributes[$offset]);
+    }
+}

--- a/tests/Unit/Classes/API/MultipartPayloadTest.php
+++ b/tests/Unit/Classes/API/MultipartPayloadTest.php
@@ -66,7 +66,7 @@ class MultipartPayloadTest extends TestCase
         $format = $payload->format();
         $this->assertEquals('multipart/form-data', $format['Content-Type']);
         $this->assertEquals('my_image', $format['name']);
-        $this->assertInternalType('resource', $format['contents']);
+        $this->assertIsResource($format['contents']);
         $this->assertEquals('image/jpg', $format['mime']);
 
         $array = ['id' => 5];

--- a/tests/Unit/Classes/APIServiceTest.php
+++ b/tests/Unit/Classes/APIServiceTest.php
@@ -70,7 +70,7 @@ class APIServiceTest extends GuzzleTestCase
             $this->wasExpectingException(RestException::class);
         } catch (RestException $ex) {
             $this->assertEquals(500, $ex->getCode());
-            $this->assertContains('bad stuff', $ex->getMessage());
+            $this->assertStringContainsString('bad stuff', $ex->getMessage());
         }
     }
 
@@ -114,7 +114,7 @@ class APIServiceTest extends GuzzleTestCase
             ]);
             $this->wasExpectingException(RestException::class);
         } catch (RestException $ex) {
-            $this->assertContains('you are bad', $ex->getMessage());
+            $this->assertStringContainsString('you are bad', $ex->getMessage());
             $this->assertEquals(422, $ex->getCode());
         }
 
@@ -124,7 +124,7 @@ class APIServiceTest extends GuzzleTestCase
             ]);
             $this->wasExpectingException(RestException::class);
         } catch (RestException $ex) {
-            $this->assertContains('i am bad', $ex->getMessage());
+            $this->assertStringContainsString('i am bad', $ex->getMessage());
             $this->assertEquals(500, $ex->getCode());
         }
 
@@ -135,7 +135,7 @@ class APIServiceTest extends GuzzleTestCase
             ]);
             $this->wasExpectingException(InvalidArgumentException::class);
         } catch (InvalidArgumentException $ex) {
-            $this->assertContains(MultipartPayload::class, $ex->getMessage());
+            $this->assertStringContainsString(MultipartPayload::class, $ex->getMessage());
             $this->assertEquals(500, $ex->getCode());
         }
     }

--- a/tests/Unit/Classes/GenericUtilityTest.php
+++ b/tests/Unit/Classes/GenericUtilityTest.php
@@ -85,7 +85,7 @@ class GenericUtilityTest extends TestCase
         try {
             $utility->call();
         } catch (UtilityException $ex) {
-            $this->assertContains('threw an exception', $ex->getMessage());
+            $this->assertStringContainsString('threw an exception', $ex->getMessage());
         }
     }
 }

--- a/tests/Unit/Classes/ImmutableModelTest.php
+++ b/tests/Unit/Classes/ImmutableModelTest.php
@@ -54,7 +54,7 @@ class ImmutableModelTest extends TestCase
             new ImmutableModel('banana');
             $this->fail('Immutable Banana created');
         } catch (InvalidArgumentException $ex) {
-            $this->assertContains('array or object', $ex->getMessage());
+            $this->assertStringContainsString('array or object', $ex->getMessage());
         }
     }
 }

--- a/tests/Unit/Classes/ImmutableObjectTest.php
+++ b/tests/Unit/Classes/ImmutableObjectTest.php
@@ -37,7 +37,7 @@ class ImmutableObjectTest extends TestCase
             new ImmutableObject('string');
             $this->fail('Exception not thrown');
         } catch (InvalidArgumentException $ex) {
-            $this->assertContains('array', $ex->getMessage());
+            $this->assertStringContainsString('array', $ex->getMessage());
         }
     }
 
@@ -90,7 +90,7 @@ class ImmutableObjectTest extends TestCase
             $this->fail($ex->__toString());
         }
 
-        $this->assertInternalType('string', $errors);
+        $this->assertIsString($errors);
     }
 
     /**
@@ -105,14 +105,14 @@ class ImmutableObjectTest extends TestCase
             $obj->isValid();
             $this->fail('Was expecting ' . ImmutableObjectException::class);
         } catch (ImmutableObjectException $ex) {
-            $this->assertContains('isValid', $ex->getMessage());
+            $this->assertStringContainsString('isValid', $ex->getMessage());
         }
 
         try {
             $obj->getValidationMessage();
             $this->fail('Was expecting ' . ImmutableObjectException::class);
         } catch (ImmutableObjectException $ex) {
-            $this->assertContains('without', $ex->getMessage());
+            $this->assertStringContainsString('without', $ex->getMessage());
         }
     }
 }

--- a/tests/Unit/Classes/StandardOutputTest.php
+++ b/tests/Unit/Classes/StandardOutputTest.php
@@ -23,10 +23,10 @@ class StandardOutputTest extends TestCase
         $std->comment('hello there');
         $result = ob_get_clean();
 
-        $this->assertContains('hello there', $result);
-        $this->assertContains('[1;34m', $result);
-        $this->assertContains("\n", $result);
-        $this->assertContains("\r", $result);
+        $this->assertStringContainsString('hello there', $result);
+        $this->assertStringContainsString('[1;34m', $result);
+        $this->assertStringContainsString("\n", $result);
+        $this->assertStringContainsString("\r", $result);
     }
 
     /**
@@ -42,10 +42,10 @@ class StandardOutputTest extends TestCase
         $std->error('hello there');
         $result = ob_get_clean();
 
-        $this->assertContains('hello there', $result);
-        $this->assertContains('[41m', $result);
-        $this->assertContains("\n\n", $result);
-        $this->assertContains("\r", $result);
+        $this->assertStringContainsString('hello there', $result);
+        $this->assertStringContainsString('[41m', $result);
+        $this->assertStringContainsString("\n\n", $result);
+        $this->assertStringContainsString("\r", $result);
     }
 
     /**
@@ -61,10 +61,10 @@ class StandardOutputTest extends TestCase
         $std->info('hello there');
         $result = ob_get_clean();
 
-        $this->assertContains('hello there', $result);
-        $this->assertContains('[32m', $result);
-        $this->assertContains("\n", $result);
-        $this->assertContains("\r", $result);
+        $this->assertStringContainsString('hello there', $result);
+        $this->assertStringContainsString('[32m', $result);
+        $this->assertStringContainsString("\n", $result);
+        $this->assertStringContainsString("\r", $result);
     }
 
     /**
@@ -80,9 +80,9 @@ class StandardOutputTest extends TestCase
         $std->line('hello there');
         $result = ob_get_clean();
 
-        $this->assertContains('hello there', $result);
-        $this->assertNotContains("\n", $result);
-        $this->assertContains("\r", $result);
+        $this->assertStringContainsString('hello there', $result);
+        $this->assertStringNotContainsString("\n", $result);
+        $this->assertStringContainsString("\r", $result);
     }
 
     /**

--- a/tests/Unit/Database/APIAssociatesTest.php
+++ b/tests/Unit/Database/APIAssociatesTest.php
@@ -64,7 +64,7 @@ class APIAssociatesTest extends TestCase
             $mock->hasManyFromApi($db, 'Whatever');
             $this->fail('Was expecting ' . ApiRelationException::class);
         } catch (ApiRelationException $ex) {
-            $this->assertContains('table', $ex->getMessage());
+            $this->assertStringContainsString('table', $ex->getMessage());
         }
 
         unset($mock->id);
@@ -73,7 +73,7 @@ class APIAssociatesTest extends TestCase
             $mock->hasManyFromApi($db, 'Whatever');
             $this->fail('Was expecting ' . ApiRelationException::class);
         } catch (ApiRelationException $ex) {
-            $this->assertContains('id', $ex->getMessage());
+            $this->assertStringContainsString('id', $ex->getMessage());
         }
     }
 }

--- a/tests/Unit/Database/ApiModelTest.php
+++ b/tests/Unit/Database/ApiModelTest.php
@@ -71,7 +71,7 @@ class ApiModelTest extends TestCase
             $model->update([]);
             $this->wasExpectingException(ApiRelationException::class);
         } catch (ApiRelationException $ex) {
-            $this->assertContains('id', $ex->getMessage());
+            $this->assertStringContainsString('id', $ex->getMessage());
         }
     }
 }

--- a/tests/Unit/Database/ComplexQueryParserTest.php
+++ b/tests/Unit/Database/ComplexQueryParserTest.php
@@ -40,7 +40,7 @@ class ComplexQueryParserTest extends TestCase
             $parser->query('hello', 'banana', 'in:1,2,3');
             $this->wasExpectingException(InvalidArgumentException::class);
         } catch (InvalidArgumentException $ex) {
-            $this->assertContains('Builder', $ex->getMessage());
+            $this->assertStringContainsString('Builder', $ex->getMessage());
         }
 
         /** @var Builder|MockObject $query */

--- a/tests/Unit/Database/HasManyFromAPITest.php
+++ b/tests/Unit/Database/HasManyFromAPITest.php
@@ -91,7 +91,7 @@ class HasManyFromAPITest extends TestCase
         try {
             $has->associate(['1']);
         } catch (InvalidArgumentException $ex) {
-            $this->assertContains('int', $ex->getMessage());
+            $this->assertStringContainsString('int', $ex->getMessage());
         } catch (Throwable $ex) {
             $this->fail($ex->__toString());
         }
@@ -248,7 +248,6 @@ class HasManyFromAPITest extends TestCase
                 ['id' => 3],
             ]));
 
-
         /** @var ConnectionInterface|\PHPUnit\Framework\MockObject\MockObject $connection */
         $connection = $this->getMockBuilder(ConnectionInterface::class)
             ->getMock();
@@ -259,7 +258,6 @@ class HasManyFromAPITest extends TestCase
         $db->method('connection')
             ->willReturn($connection);
 
-        $match = new Collection();
         $has = new HasManyFromAPI($db, 1, 'bananas', 'strawberries');
 
         $match = null;
@@ -268,7 +266,6 @@ class HasManyFromAPITest extends TestCase
         } catch (Throwable $ex) {
             $this->fail($ex->__toString());
         }
-
 
         $this->assertInstanceOf(stdClass::class, $match->first());
         $this->assertInstanceOf(Collection::class, $match);
@@ -321,7 +318,7 @@ class HasManyFromAPITest extends TestCase
             $hasMany->load();
             $this->wasExpectingException(ApiRelationException::class);
         } catch (ApiRelationException $ex) {
-            $this->assertContains('loader', $ex->getMessage());
+            $this->assertStringContainsString('loader', $ex->getMessage());
         }
 
         $hasMany = new HasManyFromAPI($db, 1, 'bananas', 'strawberries', static function ($results) {
@@ -380,7 +377,7 @@ class HasManyFromAPITest extends TestCase
             $hasMany->load();
             $this->wasExpectingException(ApiRelationException::class);
         } catch (ApiRelationException $ex) {
-            $this->assertContains('loader', $ex->getMessage());
+            $this->assertStringContainsString('loader', $ex->getMessage());
         }
 
         $hasMany = new HasManyFromAPI($db, 1, 'bananas', 'strawberries', static function ($results) {

--- a/tests/Unit/Exceptions/InvalidPayloadExceptionTest.php
+++ b/tests/Unit/Exceptions/InvalidPayloadExceptionTest.php
@@ -20,8 +20,8 @@ class InvalidPayloadExceptionTest extends TestCase
         $banana = [];
         $ex = new InvalidPayloadException($banana, 'Campaign', 'Strawberry', self::class);
         $message = $ex->getMessage();
-        $this->assertContains('Campaign', $message);
-        $this->assertContains('Strawberry', $message);
-        $this->assertContains('InvalidPayloadExceptionTest', $message);
+        $this->assertStringContainsString('Campaign', $message);
+        $this->assertStringContainsString('Strawberry', $message);
+        $this->assertStringContainsString('InvalidPayloadExceptionTest', $message);
     }
 }

--- a/tests/Unit/Testing/SmartAssertionsTest.php
+++ b/tests/Unit/Testing/SmartAssertionsTest.php
@@ -18,6 +18,8 @@ class SmartAssertionsTest extends TestCase
      * Test
      *
      * @return void
+     *
+     * @throws Throwable
      */
     public function testResponseOk(): void
     {
@@ -34,7 +36,7 @@ class SmartAssertionsTest extends TestCase
             $result = $ex->getMessage();
         }
 
-        $this->assertContains('bad news', $result);
+        $this->assertStringContainsString('bad news', $result);
 
         try {
             $test->assertStatusOk(new Response(json_encode([
@@ -45,7 +47,7 @@ class SmartAssertionsTest extends TestCase
             $result = $ex->getMessage();
         }
 
-        $this->assertContains('invalid', $result);
+        $this->assertStringContainsString('invalid', $result);
 
         try {
             $test->assertStatusOk(new Response(json_encode([
@@ -58,8 +60,8 @@ class SmartAssertionsTest extends TestCase
             $result = $ex->getMessage();
         }
 
-        $this->assertContains(__FILE__, $result);
-        $this->assertContains('666', $result);
+        $this->assertStringContainsString(__FILE__, $result);
+        $this->assertStringContainsString('666', $result);
 
         try {
             $test->assertStatusOk(new Response('hi', 500));
@@ -67,7 +69,7 @@ class SmartAssertionsTest extends TestCase
             $result = $ex->getMessage();
         }
 
-        $this->assertContains('hi', $result);
+        $this->assertStringContainsString('hi', $result);
 
         try {
             $test->assertStatusOk(new Response(['id' => 1], 500));
@@ -75,13 +77,15 @@ class SmartAssertionsTest extends TestCase
             $result = $ex->getMessage();
         }
 
-        $this->assertContains(json_encode(['id' => 1]), $result);
+        $this->assertStringContainsString(json_encode(['id' => 1]), $result);
     }
 
     /**
      * Test filtering
      *
      * @return void
+     *
+     * @throws Throwable
      */
     public function testFiltering(): void
     {
@@ -105,6 +109,6 @@ class SmartAssertionsTest extends TestCase
             $result = $ex->getMessage();
         }
 
-        $this->assertContains('strawberry', $result);
+        $this->assertStringContainsString('strawberry', $result);
     }
 }

--- a/tests/Unit/Testing/TestCaseTest.php
+++ b/tests/Unit/Testing/TestCaseTest.php
@@ -16,6 +16,7 @@ class TestCaseTest extends TestCase
      * Test was expecting
      *
      * @return void
+     * @throws Throwable
      */
     public function testWasExpecting(): void
     {
@@ -25,13 +26,13 @@ class TestCaseTest extends TestCase
         try {
             $test->wasExpectingException(InvalidArgumentException::class);
         } catch (Throwable $ex) {
-            $this->assertContains(InvalidArgumentException::class, $ex->getMessage());
+            $this->assertStringContainsString(InvalidArgumentException::class, $ex->getMessage());
         }
 
         try {
             $test->wasExpectingException('string');
         } catch (Throwable $ex) {
-            $this->assertContains('must', $ex->getMessage());
+            $this->assertStringContainsString('must', $ex->getMessage());
         }
     }
 }


### PR DESCRIPTION
lets you access immutable objects like arrays

$response->content
$response['content']


Fixes up the tests for phpunit 8
Fixes linting errors