### PR TITLE
feat(shared): campaign provides its medium associations

### DIFF
--- a/src/Interfaces/MarketingSuite/Campaign.php
+++ b/src/Interfaces/MarketingSuite/Campaign.php
@@ -35,6 +35,8 @@ use Vicimus\Support\Interfaces\Eloquent;
  * @property bool $send_optimization
  * @property bool $send_bdc
  * @property bool $send_sms
+ * @property Carbon $print_request
+ * @property Carbon $sms_at
  */
 interface Campaign extends Eloquent
 {
@@ -70,6 +72,13 @@ interface Campaign extends Eloquent
      * @return bool
      */
     public function medium(string $slug): bool;
+
+    /**
+     * Return an array of campaign medium toggles with their associated datetime value
+     *
+     * @return mixed[]
+     */
+    public function mediumAssociations(): array;
 
     /**
      * Get the OEM for this campaign


### PR DESCRIPTION
I needed this for retention as a way to say, when the send_email toggle is on, look at the email_at value etc. I don't know if this provides value in conquest, it may not, but the timing service uses this contract so I added it here.

https://vicimus.atlassian.net/browse/BUMP-5826