### PR TITLE
feat(shared): placeholder data store optional

### DIFF
--- a/src/Interfaces/MarketingSuite/Assets/PlaceholderData.php
+++ b/src/Interfaces/MarketingSuite/Assets/PlaceholderData.php
@@ -38,7 +38,7 @@ interface PlaceholderData
 
     /**
      * Get the store to use
-     * @return Store
+     * @return Store|null
      */
-    public function store(): Store;
+    public function store(): ?Store;
 }


### PR DESCRIPTION
Allows store to be nullable on the placeholder data service. This is necessary when generating previews and we have no store.

https://vicimus.atlassian.net/browse/BUMP-6400