### PR TITLE
fix(conquest): audience does not have to provide criteria

### DIFF
--- a/src/Interfaces/MarketingSuite/Audience.php
+++ b/src/Interfaces/MarketingSuite/Audience.php
@@ -8,8 +8,9 @@ use Illuminate\Database\Eloquent\Relations\MorphTo;
 /**
  * Interface Audience
  * @property int $id
- * @property Audience $extension
  * @property int $estimated
+ * @property bool $preset
+ * @property Audience $extension
  * @property Campaign|SourceRecord|mixed $audienceable
  */
 interface Audience extends HasProperties

--- a/src/Interfaces/MarketingSuite/Audience.php
+++ b/src/Interfaces/MarketingSuite/Audience.php
@@ -23,9 +23,9 @@ interface Audience extends HasProperties
 
     /**
      * Retrieve the criteria from the audience
-     * @return CriteriaContract
+     * @return CriteriaContract|null
      */
-    public function criteria(): CriteriaContract;
+    public function criteria(): ?CriteriaContract;
 
     /**
      * An audience may extend another audience as AudienceContract;

--- a/src/Interfaces/MarketingSuite/PurlContract.php
+++ b/src/Interfaces/MarketingSuite/PurlContract.php
@@ -5,6 +5,8 @@ namespace Vicimus\Support\Interfaces\MarketingSuite;
 use Illuminate\Http\Request;
 use Retention\Exceptions\PurlException;
 use Retention\Exceptions\TemplateException;
+use Vicimus\Onyx\Exceptions\OnyxException;
+use Vicimus\Support\Interfaces\Store;
 
 /**
  * Interface PurlContract
@@ -33,4 +35,15 @@ interface PurlContract
      * @throws PurlException
      */
     public function response(Request $request): PurlResponse;
+
+    /**
+     * Get the store for the specified subdomain
+     *
+     * @param string|null $subdomain The subdomain to use in the search
+     *
+     * @return Store
+     * @throws OnyxException
+     * @throws PurlException
+     */
+    public function store(?string $subdomain): Store;
 }


### PR DESCRIPTION
When uploading a custom audience to Facebook the complex criteria is not necessary. It's just an array of custom audience ids on Facebook.

https://vicimus.atlassian.net/browse/BUMP-6399