### PR TITLE
dev(shared): remove identifier from campaign contract

### DIFF
--- a/src/Interfaces/MarketingSuite/Campaign.php
+++ b/src/Interfaces/MarketingSuite/Campaign.php
@@ -91,15 +91,6 @@ interface Campaign extends Eloquent
     public function hasPortfolioBeenModified(): bool;
 
     /**
-     * Retrieve an identifier to use for an asset slug
-     *
-     * @param string $type The asset type slug
-     *
-     * @return string
-     */
-//    public function identifier(string $type): string;
-
-    /**
      * Is the campaign email only
      *
      * @return bool

--- a/src/Interfaces/MarketingSuite/Campaign.php
+++ b/src/Interfaces/MarketingSuite/Campaign.php
@@ -97,7 +97,7 @@ interface Campaign extends Eloquent
      *
      * @return string
      */
-    public function identifier(string $type): string;
+//    public function identifier(string $type): string;
 
     /**
      * Is the campaign email only


### PR DESCRIPTION
This is replaced by the Launchable interface, which is only implemented by the Conquest campaign type ( and InventoryCampaignVehicle) and allows the identifier() method to be removed from other campaign types which it made no sense for. 
This change frees up the identifier method, used by Identifiable interface which InventoryCampaignVehicle also implements. 

https://vicimus.atlassian.net/browse/BUMP-7180