### PR TITLE
dev(shared): data sources create

### DIFF
--- a/src/Interfaces/MarketingSuite/Audience.php
+++ b/src/Interfaces/MarketingSuite/Audience.php
@@ -64,5 +64,5 @@ interface Audience extends HasProperties
      *
      * @return Target
      */
-    public function target(bool $pure = true): Target;
+    public function target(AssetRecord $asset, bool $pure = true): Target;
 }

--- a/src/Interfaces/MarketingSuite/Audience.php
+++ b/src/Interfaces/MarketingSuite/Audience.php
@@ -60,9 +60,10 @@ interface Audience extends HasProperties
     /**
      * Get a target instance representing who the audience targets
      *
-     * @param bool $pure Flag to manipulate the target values
+     * @param null|AssetRecord $asset The asset being targeted
+     * @param bool             $pure  Flag to manipulate the target values
      *
      * @return Target
      */
-    public function target(AssetRecord $asset, bool $pure = true): Target;
+    public function target(?AssetRecord $asset, bool $pure = true): Target;
 }

--- a/src/Interfaces/MarketingSuite/Campaign.php
+++ b/src/Interfaces/MarketingSuite/Campaign.php
@@ -65,12 +65,6 @@ interface Campaign extends Eloquent
     public function assets(): MorphMany;
 
     /**
-     * Retrieve associated categories
-     * @return string[]
-     */
-    public function categories(): array;
-
-    /**
      * Retrieve a Carbon Copy for a campaign
      *
      * @return Prospect|null

--- a/src/Interfaces/MarketingSuite/ConquestDataSource.php
+++ b/src/Interfaces/MarketingSuite/ConquestDataSource.php
@@ -2,10 +2,8 @@
 
 namespace Vicimus\Support\Interfaces\MarketingSuite;
 
-use Conquest\Exceptions\DataSourceException;
 use DateTimeInterface;
 use Illuminate\Support\Collection;
-use Vicimus\Facebook\Exceptions\FacebookException;
 use Vicimus\Support\Classes\ConquestCompatibilityMatrix;
 use Vicimus\Support\Classes\ConquestDataSourceInfo;
 use Vicimus\Support\Classes\Grouping;

--- a/src/Interfaces/MarketingSuite/ConquestDataSource.php
+++ b/src/Interfaces/MarketingSuite/ConquestDataSource.php
@@ -2,8 +2,10 @@
 
 namespace Vicimus\Support\Interfaces\MarketingSuite;
 
+use Conquest\Exceptions\DataSourceException;
 use DateTimeInterface;
 use Illuminate\Support\Collection;
+use Vicimus\Facebook\Exceptions\FacebookException;
 use Vicimus\Support\Classes\ConquestCompatibilityMatrix;
 use Vicimus\Support\Classes\ConquestDataSourceInfo;
 use Vicimus\Support\Classes\Grouping;
@@ -84,6 +86,17 @@ interface ConquestDataSource
      * @return ConquestCompatibilityMatrix
      */
     public function compatibility(): ConquestCompatibilityMatrix;
+
+    /**
+     * Create a campaign for the source
+     *
+     * @param HasSource    $campaign The local campaign
+     * @param SourceRecord $source   The campaign source
+     *
+     * @return void
+     * @throws DataSourceException
+     */
+    public function create(HasSource $campaign, SourceRecord $source): void;
 
     /**
      * Retrieve the credentials for a source from the provided store
@@ -174,6 +187,15 @@ interface ConquestDataSource
      * @throws DataSourceException
      */
     public function launch(Campaign $campaign, SourceRecord $source, Collection $assets): void;
+
+    /**
+     * Mediums on the sourceable item where changed
+     *
+     * @param SourceRecord $source The source related to the update
+     *
+     * @return void
+     */
+    public function mediumsUpdated(SourceRecord $source): void;
 
     /**
      * The name of the data source as it should be displayed to clients

--- a/src/Interfaces/MarketingSuite/HasSource.php
+++ b/src/Interfaces/MarketingSuite/HasSource.php
@@ -5,11 +5,16 @@ namespace Vicimus\Support\Interfaces\MarketingSuite;
 use Assets\Models\Source;
 use Illuminate\Database\Eloquent\Relations\MorphMany;
 use Illuminate\Database\Eloquent\Relations\MorphOne;
+use Illuminate\Support\Carbon;
 
 /**
  * Interface HasSource
  *
- *
+ * @property int $id
+ * @property string $title
+ * @property Carbon $end
+ * @property Carbon $start
+ * @property Audience[] $audiences
  */
 interface HasSource
 {
@@ -24,6 +29,12 @@ interface HasSource
      * @return MorphMany
      */
     public function audiences(): MorphMany;
+
+    /**
+     * Retrieve associated datasource categories
+     * @return string[]
+     */
+    public function categories(): array;
 
     /**
      * Retrieve the related source


### PR DESCRIPTION
Audience::target() accepts the asset type, this allows the specific placements to be added for the target.
Categories removed from campaign contract, this has been moved to the HasSource interface as it makes no sense for retention to implement this.
DataSource has two be methods: 
create, so campaigns can be created separately from 'other things' like publishing assets which take time, but allows the creation request to fail in real time.
mediumsUpdated, so that if an asset is enabled/disabled post launch the ad sets can be synchronized appropriately. This is no longer used after the change to only send to the source after launching - since assets aren't editable after the fact - but they could be and will be in inventory ads.

https://vicimus.atlassian.net/browse/BUMP-7367