### PR TITLE
dev(shared): audience remoteId

### DIFF
--- a/src/Interfaces/MarketingSuite/Audience.php
+++ b/src/Interfaces/MarketingSuite/Audience.php
@@ -67,4 +67,10 @@ interface Audience extends HasProperties
      * @return Target
      */
     public function target(?Creatable $asset, bool $pure = true): Target;
+
+    /**
+     * Retrieve the remote id used by the audience
+     * @return int|null
+     */
+    public function remoteId(): ?int;
 }

--- a/src/Interfaces/MarketingSuite/Audience.php
+++ b/src/Interfaces/MarketingSuite/Audience.php
@@ -59,6 +59,12 @@ interface Audience extends HasProperties
     public function name(): string;
 
     /**
+     * Retrieve the remote id used by the audience
+     * @return int|null
+     */
+    public function remoteId(): ?int;
+
+    /**
      * Get a target instance representing who the audience targets
      *
      * @param null|Creatable $asset The asset being targeted
@@ -67,10 +73,4 @@ interface Audience extends HasProperties
      * @return Target
      */
     public function target(?Creatable $asset, bool $pure = true): Target;
-
-    /**
-     * Retrieve the remote id used by the audience
-     * @return int|null
-     */
-    public function remoteId(): ?int;
 }


### PR DESCRIPTION
Adds a method to parse a remote id from an audience. This is necessary so that if a saved facebook audience is selected for a campaign, the audience can be found and displayed to the user.

https://vicimus.atlassian.net/browse/BUMP-8097