### PR TITLE
dev(inventory-ads): audience targeting tweaks

### DIFF
--- a/src/Interfaces/MarketingSuite/Audience.php
+++ b/src/Interfaces/MarketingSuite/Audience.php
@@ -67,10 +67,10 @@ interface Audience extends HasProperties
     /**
      * Get a target instance representing who the audience targets
      *
-     * @param null|Creatable $asset The asset being targeted
-     * @param bool           $pure  Flag to manipulate the target values
+     * @param null|string $placement The asset placement slug
+     * @param bool        $pure      Flag to manipulate the target values
      *
      * @return Target
      */
-    public function target(?Creatable $asset, bool $pure = true): Target;
+    public function target(?string $placement, bool $pure = true): Target;
 }

--- a/src/Interfaces/MarketingSuite/Audience.php
+++ b/src/Interfaces/MarketingSuite/Audience.php
@@ -4,7 +4,6 @@ namespace Vicimus\Support\Interfaces\MarketingSuite;
 
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
-use Vicimus\Support\Interfaces\MarketingSuite\Assets\Creatable;
 
 /**
  * Interface Audience

--- a/src/Interfaces/MarketingSuite/ConquestDataSource.php
+++ b/src/Interfaces/MarketingSuite/ConquestDataSource.php
@@ -267,6 +267,8 @@ interface ConquestDataSource extends PropertyProvider
      * @param SourceRecord $source  The data source
      * @param string[]     $payload The update payload
      * @return void
+     *
+     * @throws DataSourceException
      */
     public function reschedule(SourceRecord $source, array $payload): void;
 

--- a/src/Interfaces/MarketingSuite/HasSource.php
+++ b/src/Interfaces/MarketingSuite/HasSource.php
@@ -16,6 +16,7 @@ use Illuminate\Support\Collection;
  * @property string $title
  * @property Carbon $end
  * @property Carbon $start
+ * @property Carbon $launched_at
  */
 interface HasSource
 {


### PR DESCRIPTION
Changes typehint on audiences target method, it was passing the 'creatable' to get an asset type slug off of it. Im working with ad sets now more often, so now just pass the placement type directly.

https://vicimus.atlassian.net/browse/BUMP-8142