### PR TITLE
dev(shared): source has save 

### DIFF
--- a/src/Interfaces/MarketingSuite/ConquestDataSource.php
+++ b/src/Interfaces/MarketingSuite/ConquestDataSource.php
@@ -273,6 +273,15 @@ interface ConquestDataSource extends PropertyProvider
     public function reschedule(SourceRecord $source, array $payload): void;
 
     /**
+     * Method triggered on source initial save
+     *
+     * @param SourceRecord $source The source saved
+     *
+     * @return void
+     */
+    public function save(SourceRecord $source): void;
+
+    /**
      * Report on the status of an asset. APPROVED, PENDING or REJECTED
      *
      * @param AssetRecord $asset The asset


### PR DESCRIPTION
Adds a save method to the source contract so that if a source needs to do somethign special on it's creation (generate assets/identifiers) it is handled at the source level.

https://vicimus.atlassian.net/browse/BUMP-8212