### PR TITLE
dev(shared): data source provides supported

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "illuminate/validation": "^7.0 || ^6.0 || ~5",
         "illuminate/view": "^7.0 || ^6.0 || ^5.8",
         "mikey179/vfsstream": "^1.6",
-        "phpunit/phpunit": "~8",
+        "phpunit/phpunit": "^9",
         "symfony/browser-kit": "^4.3",
         "symfony/var-dumper": "^4.2",
         "vicimus/standard": "^4.1.2"

--- a/src/Classes/ConquestDataSourceInfo.php
+++ b/src/Classes/ConquestDataSourceInfo.php
@@ -12,6 +12,7 @@ namespace Vicimus\Support\Classes;
  * @property ConquestCompatibilityMatrix $matrix
  * @property string[]                    $mediums
  * @property string                      $error
+ * @property string[]                    $supported
  */
 class ConquestDataSourceInfo extends ImmutableObject
 {
@@ -25,6 +26,7 @@ class ConquestDataSourceInfo extends ImmutableObject
      * @param ConquestCompatibilityMatrix $matrix      The compatibility matrix
      * @param string[]                    $mediums     The supported medium types
      * @param string                      $icon        The source icon
+     * @param string[]                    $supported   The campaign types supported by the source
      */
     public function __construct(
         string $name,
@@ -33,7 +35,8 @@ class ConquestDataSourceInfo extends ImmutableObject
         string $category,
         ConquestCompatibilityMatrix $matrix,
         array $mediums,
-        string $icon
+        string $icon,
+        array $supported
     ) {
         parent::__construct([
             'name' => $name,
@@ -43,6 +46,7 @@ class ConquestDataSourceInfo extends ImmutableObject
             'matrix' => $matrix,
             'mediums' => $mediums,
             'icon' => $icon,
+            'supported' => $supported,
         ]);
     }
 

--- a/tests/Unit/Classes/ConquestDataSourceInfoTest.php
+++ b/tests/Unit/Classes/ConquestDataSourceInfoTest.php
@@ -27,7 +27,8 @@ class ConquestDataSourceInfoTest extends TestCase
                 'banana' => 'strawberry',
             ]),
             ['facebook_carousel'],
-            'fa-facebook'
+            'fa-facebook',
+            []
         );
 
         $info->setError('Banana!');


### PR DESCRIPTION
Datasource is aware of the campaigns which it supports. This allows purl only campaigns to be only offered on conquest campaigns.

https://vicimus.atlassian.net/browse/BUMP-8274