### PR TITLE
dev(shared): purl manager has background

### DIFF
--- a/src/Interfaces/MarketingSuite/PurlContract.php
+++ b/src/Interfaces/MarketingSuite/PurlContract.php
@@ -14,6 +14,14 @@ use Vicimus\Support\Interfaces\Store;
 interface PurlContract
 {
     /**
+     * Retrieve the path to the background image for a campaign
+     *
+     * @param int $campaignId The campaign
+     * @return string
+     */
+    public function background(int $campaignId): string;
+
+    /**
      * Pinging is a way to
      *
      * @param int $campaignId The campaign id


### PR DESCRIPTION
Purl manager instance is capable of finding a background for a provided campaign id.

https://vicimus.atlassian.net/browse/BUMP-8256