### PR TITLE
dev(retention): rewrote gatherer and added many filter controls

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -52,7 +52,10 @@
         ]
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {
+            "dealerdirect/phpcodesniffer-composer-installer": true
+        }
     },
     "description": "Many support classes and interfaces"
 }

--- a/src/Interfaces/Filtering/Campaign.php
+++ b/src/Interfaces/Filtering/Campaign.php
@@ -2,6 +2,7 @@
 
 namespace Vicimus\Support\Interfaces\Filtering;
 
+use Carbon\Carbon;
 use DateTime;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\HasOne;
@@ -19,8 +20,8 @@ use Vicimus\Support\Interfaces\MarketingSuite\Campaign as BaseCampaign;
  * @property int $store_id
  * @property \Bumper\Models\Collection[] $collections
  * @property \Illuminate\Database\Eloquent\Collection|Model $approvals
- * @property DateTime $start
- * @property DateTime $end
+ * @property Carbon $start
+ * @property Carbon $end
  * @property string $oem
  * @property bool $send_email
  * @property bool $send_letter
@@ -33,24 +34,24 @@ use Vicimus\Support\Interfaces\MarketingSuite\Campaign as BaseCampaign;
  * @property string $parent_url
  * @property \Illuminate\Database\Eloquent\Collection|Model[] $excludes
  * @property \Illuminate\Database\Eloquent\Collection|Model[] $departments
- * @property DateTime $created_at
- * @property DateTime $updated_at
+ * @property Carbon $created_at
+ * @property Carbon $updated_at
  * @property bool $live_site
  * @property string $purl_background
  * @property string[] $purl_dates
  * @property string $description
  * @property string $sign_off_name
  * @property string $sign_off_title
- * @property DateTime $launched_at
- * @property DateTime $printed_atd
- * @property DateTime $emailed_at
- * @property DateTime $previewed_at
- * @property DateTime $expired_at
- * @property DateTime $cancelled_at
- * @property DateTime $approved_at
- * @property DateTime $print_at
- * @property DateTime $previews_at
- * @property DateTime $generated_at
+ * @property Carbon $launched_at
+ * @property Carbon $printed_atd
+ * @property Carbon $emailed_at
+ * @property Carbon $previewed_at
+ * @property Carbon $expired_at
+ * @property Carbon $cancelled_at
+ * @property Carbon $approved_at
+ * @property Carbon $print_at
+ * @property Carbon $previews_at
+ * @property Carbon $generated_at
  * @property bool $subject_customized
  * @property bool $has_associated
  */

--- a/src/Interfaces/Filtering/Campaign.php
+++ b/src/Interfaces/Filtering/Campaign.php
@@ -3,7 +3,6 @@
 namespace Vicimus\Support\Interfaces\Filtering;
 
 use Carbon\Carbon;
-use DateTime;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\HasOne;
 use Illuminate\Database\Eloquent\Relations\MorphMany;

--- a/src/Interfaces/Filtering/Campaign.php
+++ b/src/Interfaces/Filtering/Campaign.php
@@ -52,6 +52,7 @@ use Vicimus\Support\Interfaces\MarketingSuite\Campaign as BaseCampaign;
  * @property DateTime $previews_at
  * @property DateTime $generated_at
  * @property bool $subject_customized
+ * @property bool $has_associated
  */
 interface Campaign extends BaseCampaign
 {

--- a/src/Interfaces/Filtering/Gatherer.php
+++ b/src/Interfaces/Filtering/Gatherer.php
@@ -19,6 +19,16 @@ interface Gatherer
      */
     public function count(Filter $filter, Campaign $campaign): int;
 
+    /**
+     * Get customer information
+     *
+     * @param Filter|null              $filter         The filter
+     * @param Campaign                 $campaign       The campaign
+     * @param ResultConfiguration|null $customerFilter The customer filter info for paging
+     * @param int                      $preferRecorded Prefer recorded or theoretical
+     *
+     * @return mixed
+     */
     public function customers(
         ?Filter $filter,
         Campaign $campaign,
@@ -36,5 +46,13 @@ interface Gatherer
      */
     public function stats(Filter $filter, Campaign $campaign): Stats;
 
+    /**
+     * Get a customer query object
+     *
+     * @param Filter   $filter   The filter
+     * @param Campaign $campaign The campaign
+     *
+     * @return Builder
+     */
     public function toCustomerQuery(Filter $filter, Campaign $campaign): Builder;
 }

--- a/src/Interfaces/Filtering/Gatherer.php
+++ b/src/Interfaces/Filtering/Gatherer.php
@@ -2,6 +2,8 @@
 
 namespace Vicimus\Support\Interfaces\Filtering;
 
+use Illuminate\Database\Eloquent\Builder;
+
 /**
  * Interface Gatherer
  */
@@ -15,7 +17,14 @@ interface Gatherer
      *
      * @return int
      */
-    public function count(Filter $filter, ?Campaign $campaign = null): int;
+    public function count(Filter $filter, Campaign $campaign): int;
+
+    public function customers(
+        ?Filter $filter,
+        Campaign $campaign,
+        ?ResultConfiguration $customerFilter = null,
+        int $preferRecorded = 1
+    );
 
     /**
      * Get stats for a filter and campaign
@@ -26,4 +35,6 @@ interface Gatherer
      * @return Stats
      */
     public function stats(Filter $filter, Campaign $campaign): Stats;
+
+    public function toCustomerQuery(Filter $filter, Campaign $campaign): Builder;
 }

--- a/src/Interfaces/Filtering/ResultConfiguration.php
+++ b/src/Interfaces/Filtering/ResultConfiguration.php
@@ -1,0 +1,8 @@
+<?php declare(strict_types = 1);
+
+namespace Vicimus\Support\Interfaces\Filtering;
+
+interface ResultConfiguration
+{
+
+}

--- a/src/Interfaces/Filtering/ResultConfiguration.php
+++ b/src/Interfaces/Filtering/ResultConfiguration.php
@@ -2,7 +2,10 @@
 
 namespace Vicimus\Support\Interfaces\Filtering;
 
+/**
+ * Result configuration
+ */
 interface ResultConfiguration
 {
-
+    //
 }

--- a/src/Interfaces/Filtering/Stats.php
+++ b/src/Interfaces/Filtering/Stats.php
@@ -3,7 +3,6 @@
 namespace Vicimus\Support\Interfaces\Filtering;
 
 use JsonSerializable;
-use Vicimus\Billing\Classes\CostBreakdown;
 
 /**
  * Interface Stats
@@ -14,26 +13,13 @@ use Vicimus\Billing\Classes\CostBreakdown;
  * @property int $rvms
  * @property int $excluded
  * @property int $total
- * @property CostBreakdown $cost
+ * @property mixed $cost
  * @property mixed[] $breakdown
  * @property Campaign $campaign
  * @property OptOuts $optOuts
  */
 interface Stats extends JsonSerializable
 {
-    public function emails(): int;
-
-    public function invites(): int;
-
-    public function letters(): int;
-
-    public function postcards(): int;
-
-    public function rvms(): int;
-
-    public function sms(): int;
-
-    public function total(): int;
 
     /**
      * Delete the model
@@ -43,8 +29,43 @@ interface Stats extends JsonSerializable
     public function delete(): bool;
 
     /**
+     * @return int
+     */
+    public function emails(): int;
+
+    /**
+     * @return int
+     */
+    public function invites(): int;
+
+    /**
+     * @return int
+     */
+    public function letters(): int;
+
+    /**
+     * @return int
+     */
+    public function postcards(): int;
+
+    /**
+     * @return int
+     */
+    public function rvms(): int;
+
+    /**
+     * @return int
+     */
+    public function sms(): int;
+
+    /**
      * Return all stats as an array of data
      * @return mixed[]
      */
     public function toArray(): array;
+
+    /**
+     * @return int
+     */
+    public function total(): int;
 }

--- a/src/Interfaces/Filtering/Stats.php
+++ b/src/Interfaces/Filtering/Stats.php
@@ -21,6 +21,20 @@ use Vicimus\Billing\Classes\CostBreakdown;
  */
 interface Stats extends JsonSerializable
 {
+    public function emails(): int;
+
+    public function invites(): int;
+
+    public function letters(): int;
+
+    public function postcards(): int;
+
+    public function rvms(): int;
+
+    public function sms(): int;
+
+    public function total(): int;
+
     /**
      * Delete the model
      *

--- a/src/Interfaces/OemService.php
+++ b/src/Interfaces/OemService.php
@@ -15,9 +15,9 @@ interface OemService
      *
      * @param string $slug The Make to get
      *
+     * @return Make
      * @throws RestException
      *
-     * @return Make
      */
     public function get(string $slug): Make;
 }


### PR DESCRIPTION
I rewrote our Gatherer from scratch. This is the service that converts a filter into a set of customers (as well as generates stats). Typical filter usage is the default settings plus bucket, and restrict vehicles. With those values, my new gatherer (Super Gatherer) reduces CPU usage by 94% and is around 87% faster, and also reduces the amount of time MySQL is computing by 84% which will lighten the load on our rds server as well as our web server.

In addition to this, I've added multiple new filter controls, as these all required handlers for the new gatherer, so I figured it's the best time to implement them.

https://vicimus.atlassian.net/browse/BUMP-6440
https://vicimus.atlassian.net/browse/BUMP-8652
https://vicimus.atlassian.net/browse/BUMP-8252
https://vicimus.atlassian.net/browse/BUMP-6478
https://vicimus.atlassian.net/browse/BUMP-6410
https://vicimus.atlassian.net/browse/BUMP-6502
https://vicimus.atlassian.net/browse/BUMP-6503
https://vicimus.atlassian.net/browse/BUMP-7806