### PR TITLE
fix(shared): fix date serialization to use Laravels default

### DIFF
--- a/src/Database/Model.php
+++ b/src/Database/Model.php
@@ -2,7 +2,6 @@
 
 namespace Vicimus\Support\Database;
 
-use DateTimeInterface;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model as LaravelModel;
 use Illuminate\Support\Str;

--- a/src/Database/Model.php
+++ b/src/Database/Model.php
@@ -220,16 +220,4 @@ class Model extends LaravelModel
     {
         return Str::contains($key, '.') ? last(explode('.', $key)) : $key;
     }
-
-    /**
-     * Prepare a date for array / JSON serialization.
-     *
-     * @param DateTimeInterface $date The date
-     *
-     * @return string
-     */
-    protected function serializeDate(DateTimeInterface $date): string
-    {
-        return $date->format('Y-m-d H:i:s');
-    }
 }


### PR DESCRIPTION
We used to have this for reasons, but it's messing up Safari, and I'd rather rely on default Laravel functionality and fix any issues we caused ourselves.
https://vicimus.atlassian.net/browse/BUMP-9023
https://vicimus.atlassian.net/browse/BUMP-9026