### PR TITLE
dev(shared): purl event no longer takes adf info

### DIFF
--- a/src/Interfaces/Filtering/Stats.php
+++ b/src/Interfaces/Filtering/Stats.php
@@ -24,6 +24,11 @@ use Vicimus\Support\Interfaces\Billing\CostBreakdownContract;
 interface Stats extends JsonSerializable
 {
     /**
+     * @return int
+     */
+    public function bdc(): int;
+
+    /**
      * Retrieve the cost breakdown object
      * @return CostBreakdownContract
      */

--- a/src/Interfaces/MarketingSuite/PurlEvents.php
+++ b/src/Interfaces/MarketingSuite/PurlEvents.php
@@ -3,7 +3,6 @@
 namespace Vicimus\Support\Interfaces\MarketingSuite;
 
 use Retention\Exceptions\PurlSubmissionException;
-use Vicimus\ADF\ADFInfo;
 use Vicimus\Leads\Models\Confirmation;
 use Vicimus\Support\Exceptions\RestException;
 

--- a/src/Interfaces/MarketingSuite/PurlEvents.php
+++ b/src/Interfaces/MarketingSuite/PurlEvents.php
@@ -26,7 +26,6 @@ interface PurlEvents
     /**
      * Handle purl submissions
      *
-     * @param ADFInfo  $info    The ADF info
      * @param string[] $request The request payload
      * @param int|null $lead    The lead id to be populated
      * @param bool     $testing Was this a testing submission
@@ -36,7 +35,7 @@ interface PurlEvents
      * @throws PurlSubmissionException
      * @throws RestException
      */
-    public function submission(ADFInfo $info, array $request, ?int &$lead = null, bool $testing = false): Confirmation;
+    public function submission(array $request, ?int &$lead = null, bool $testing = false): Confirmation;
 
     /**
      * Add a temperature to the records


### PR DESCRIPTION
Adf info is manually handled in the submission logic after the appropriate store is determined for whitelabelling purposes.

https://vicimus.atlassian.net/browse/BUMP-9519