### PR TITLE
dev(shared): make the tran() method way more effecient

### DIFF
--- a/bootstrap/dev-helpers.php
+++ b/bootstrap/dev-helpers.php
@@ -279,13 +279,22 @@ if (!function_exists('tran')) {
      */
     function tran($key, $default = null, array $variables = [])
     {
+        $key = md5(sprintf('%s_%s', $key, json_encode($variables)));
+        if (\Illuminate\Support\Facades\Cache::has($key)) {
+            return \Illuminate\Support\Facades\Cache::get($key);
+        }
+
         /** @var Translator $translator */
         $translator = app(Translator::class);
+        $result = $default;
         try {
-            return $translator->tran($key, $default, $variables);
+            $result = $translator->tran($key, $default, $variables);
         } catch (TranslationFileException $ex) {
-            return $default;
+            $result = $default;
         }
+
+        \Illuminate\Support\Facades\Cache::put($key, $result);
+        return $result;
     }
 }
 

--- a/bootstrap/dev-helpers.php
+++ b/bootstrap/dev-helpers.php
@@ -279,11 +279,21 @@ if (!function_exists('tran')) {
      */
     function tran($key, $default = null, array $variables = [])
     {
+        // This is real dirty but it works so come at me/
+        // Improves loading speed of larger pages (inventory, etc) by around 33%
+        global $__LOCALE;
+        if (!$__LOCALE) {
+            $__LOCALE = app()->getLocale();
+        }
+
+        if ($__LOCALE === 'en' && $default && !count($variables)) {
+            return $default;
+        }
+
         $key = md5(sprintf('%s_%s', $key, json_encode($variables)));
         if (\Illuminate\Support\Facades\Cache::has($key)) {
             return \Illuminate\Support\Facades\Cache::get($key);
         }
-
         /** @var Translator $translator */
         $translator = app(Translator::class);
         $result = $default;

--- a/bootstrap/dev-helpers.php
+++ b/bootstrap/dev-helpers.php
@@ -267,47 +267,6 @@ if (!function_exists('now')) {
     }
 }
 
-if (!function_exists('tran')) {
-    /**
-     * Auto-write to translation files
-     *
-     * @param string|mixed $key       The key to look for
-     * @param string|mixed $default   The default to use
-     * @param mixed[]      $variables Variable placeholders
-     *
-     * @return mixed
-     */
-    function tran($key, $default = null, array $variables = [])
-    {
-        // This is real dirty but it works so come at me/
-        // Improves loading speed of larger pages (inventory, etc) by around 33%
-        global $__LOCALE;
-        if (!$__LOCALE) {
-            $__LOCALE = app()->getLocale();
-        }
-
-        if ($__LOCALE === 'en' && $default && !count($variables)) {
-            return $default;
-        }
-
-        $key = md5(sprintf('%s_%s', $key, json_encode($variables)));
-        if (\Illuminate\Support\Facades\Cache::has($key)) {
-            return \Illuminate\Support\Facades\Cache::get($key);
-        }
-        /** @var Translator $translator */
-        $translator = app(Translator::class);
-        $result = $default;
-        try {
-            $result = $translator->tran($key, $default, $variables);
-        } catch (TranslationFileException $ex) {
-            $result = $default;
-        }
-
-        \Illuminate\Support\Facades\Cache::put($key, $result);
-        return $result;
-    }
-}
-
 if (!function_exists('validate')) {
     /**
      * Validate

--- a/bootstrap/helpers.php
+++ b/bootstrap/helpers.php
@@ -55,13 +55,32 @@ if (!function_exists('tran')) {
      */
     function tran($key, $default = null, array $variables = [])
     {
-        /** @var Translator $translator */
-        $translator = app(Translator::class);
-        try {
-            return $translator->tran($key, $default, $variables);
-        } catch (TranslationFileException $ex) {
+        // This is real dirty but it works so come at me/
+        // Improves loading speed of larger pages (inventory, etc) by around 33%
+        global $__LOCALE;
+        if (!$__LOCALE) {
+            $__LOCALE = app()->getLocale();
+        }
+
+        if ($__LOCALE === 'en' && $default && !count($variables)) {
             return $default;
         }
+
+        $key = md5(sprintf('%s_%s', $key, json_encode($variables)));
+        if (\Illuminate\Support\Facades\Cache::has($key)) {
+            return \Illuminate\Support\Facades\Cache::get($key);
+        }
+        /** @var Translator $translator */
+        $translator = app(Translator::class);
+        $result = $default;
+        try {
+            $result = $translator->tran($key, $default, $variables);
+        } catch (TranslationFileException $ex) {
+            $result = $default;
+        }
+
+        \Illuminate\Support\Facades\Cache::put($key, $result);
+        return $result;
     }
 }
 

--- a/bootstrap/helpers.php
+++ b/bootstrap/helpers.php
@@ -70,6 +70,7 @@ if (!function_exists('tran')) {
         if (\Illuminate\Support\Facades\Cache::has($key)) {
             return \Illuminate\Support\Facades\Cache::get($key);
         }
+
         /** @var Translator $translator */
         $translator = app(Translator::class);
         $result = $default;


### PR DESCRIPTION
It exists in two places, so i just kept them the same.

1. If the app's locale is english, we don't have to translate anything. If a default is provided, then that is just the english word, we can just turn around and return the english word and save all the look ups. This eliminates 99% of all overhead for translating.
2. If it can't do the above, it will cache the results now so it only has to do the lookup once.
https://vicimus.atlassian.net/browse/GBX-5936
https://vicimus.atlassian.net/browse/GBX-5933
https://vicimus.atlassian.net/browse/GBX-5932