### PR TITLE
fix(shared): keep the key for the tran function and use $hash variable instead

### DIFF
--- a/bootstrap/helpers.php
+++ b/bootstrap/helpers.php
@@ -76,11 +76,11 @@ if (!function_exists('tran')) {
         $result = $default;
         try {
             $result = $translator->tran($key, $default, $variables);
-            \Illuminate\Support\Facades\Cache::put($hash, $result);
         } catch (TranslationFileException $ex) {
             $result = $default;
         }
 
+        \Illuminate\Support\Facades\Cache::put($hash, $result);
         return $result;
     }
 }

--- a/bootstrap/helpers.php
+++ b/bootstrap/helpers.php
@@ -66,9 +66,9 @@ if (!function_exists('tran')) {
             return $default;
         }
 
-        $key = md5(sprintf('%s_%s', $key, json_encode($variables)));
-        if (\Illuminate\Support\Facades\Cache::has($key)) {
-            return \Illuminate\Support\Facades\Cache::get($key);
+        $hash = md5(sprintf('%s_%s', $key, json_encode($variables)));
+        if (\Illuminate\Support\Facades\Cache::has($hash)) {
+            return \Illuminate\Support\Facades\Cache::get($hash);
         }
 
         /** @var Translator $translator */
@@ -76,11 +76,11 @@ if (!function_exists('tran')) {
         $result = $default;
         try {
             $result = $translator->tran($key, $default, $variables);
+            \Illuminate\Support\Facades\Cache::put($hash, $result);
         } catch (TranslationFileException $ex) {
             $result = $default;
         }
 
-        \Illuminate\Support\Facades\Cache::put($key, $result);
         return $result;
     }
 }


### PR DESCRIPTION
The hash being created for the cache was overwriting the key being passed which is required for the tran() to work properly and find the translation.

https://vicimus.atlassian.net/browse/GBX-5941