### PR TITLE
dev(shared): adf lead has form type

### DIFF
--- a/src/Interfaces/ADF/ADFLead.php
+++ b/src/Interfaces/ADF/ADFLead.php
@@ -37,6 +37,13 @@ interface ADFLead
     public function customer(): ?ADFCustomer;
 
     /**
+     * Retrieve the name of the form used with the submission
+     *
+     * @return string|null
+     */
+    public function formType(): ?string;
+
+    /**
      * This should be a unique identifier for the lead.  Most likely the primary
      * key from the database
      *


### PR DESCRIPTION
Adds a form type method to the adf lead interface to retrieve the name of the form used for a submission

https://vicimus.atlassian.net/browse/BUMP-10598