### PR TITLE
dev(shared): fix interface

### DIFF
--- a/src/Interfaces/Glovebox/Result.php
+++ b/src/Interfaces/Glovebox/Result.php
@@ -19,7 +19,7 @@ interface Result
      *
      * @return array
      */
-    public function output(): bool;
+    public function output(): array;
 
     /**
      * Check if the command succeeded


### PR DESCRIPTION
This interface was incorrect. It also has no business being in a Glovebox namespace but it was too much work to move it at this time. Executor/Result is used in tons of projects all over, nothing to do with Gbx.
https://vicimus.atlassian.net/browse/GBX-6127