### PR TITLE
fix(gbx): add command param to theme manager

### DIFF
--- a/src/Interfaces/Glovebox/ThemeManager.php
+++ b/src/Interfaces/Glovebox/ThemeManager.php
@@ -10,6 +10,8 @@ interface ThemeManager
     /**
      * Run Grunt Web in the Eevee directory to recompile the theme scss
      *
+     * @param string $command The command to run
+     *
      * @return Result
      */
     public function refresh(string $command): Result;

--- a/src/Interfaces/Glovebox/ThemeManager.php
+++ b/src/Interfaces/Glovebox/ThemeManager.php
@@ -12,5 +12,5 @@ interface ThemeManager
      *
      * @return Result
      */
-    public function refresh(): Result;
+    public function refresh(string $command): Result;
 }


### PR DESCRIPTION
Needed to add the $command parameter to the ThemeManager interface for gbx.

https://vicimus.atlassian.net/browse/GBX-6206