### PR TITLE
dev(retention): campaign/filter questions

### DIFF
--- a/src/Interfaces/Filtering/Campaign.php
+++ b/src/Interfaces/Filtering/Campaign.php
@@ -136,4 +136,28 @@ interface Campaign extends BaseCampaign
      * @return HasOne
      */
     public function stats(): HasOne;
+
+    /**
+     * Determine if the emails should only go to active customers
+     * @return bool
+     */
+    public function useOnlyEmailActive(): bool;
+
+    /**
+     * Determine if customer preference should be used
+     * @return bool
+     */
+    public function useCustomerPreference(): bool;
+
+    /**
+     * Determine if bounced customers should be excluded
+     * @return bool
+     */
+    public function useExcludeBounced(): bool;
+
+    /**
+     * Determine if launch process should scale mediums
+     * @return bool
+     */
+    public function useScaleMediums(): bool;
 }

--- a/src/Interfaces/Filtering/Campaign.php
+++ b/src/Interfaces/Filtering/Campaign.php
@@ -138,12 +138,6 @@ interface Campaign extends BaseCampaign
     public function stats(): HasOne;
 
     /**
-     * Determine if the emails should only go to active customers
-     * @return bool
-     */
-    public function useOnlyEmailActive(): bool;
-
-    /**
      * Determine if customer preference should be used
      * @return bool
      */
@@ -154,6 +148,12 @@ interface Campaign extends BaseCampaign
      * @return bool
      */
     public function useExcludeBounced(): bool;
+
+    /**
+     * Determine if the emails should only go to active customers
+     * @return bool
+     */
+    public function useOnlyEmailActive(): bool;
 
     /**
      * Determine if launch process should scale mediums


### PR DESCRIPTION
Added for lifecycle campaigns when logic needs to know something from the campaigns filter, but lifecycle does not have a filter and stores these answers differently.

https://vicimus.atlassian.net/browse/BUMP-10840
