### PR TITLE
dev(shared): allow any object in ImmutableObject constructor

### DIFF
--- a/src/Classes/ImmutableObject.php
+++ b/src/Classes/ImmutableObject.php
@@ -9,14 +9,10 @@ use Illuminate\Contracts\Validation\Factory;
 use InvalidArgumentException;
 use JsonSerializable;
 use RuntimeException;
-use stdClass;
 use Vicimus\Support\Exceptions\ImmutableObjectException;
 use Vicimus\Support\Interfaces\WillValidate;
 use Vicimus\Support\Traits\AttributeArrayAccess;
 
-/**
- * Class ImmutableObject
- */
 class ImmutableObject implements ArrayAccess, JsonSerializable, WillValidate
 {
     use AttributeArrayAccess;

--- a/src/Classes/ImmutableObject.php
+++ b/src/Classes/ImmutableObject.php
@@ -60,7 +60,7 @@ class ImmutableObject implements ArrayAccess, JsonSerializable, WillValidate
     /**
      * @throws InvalidArgumentException
      */
-    public function __construct(stdClass | array $original = [], ?Factory $validator = null)
+    public function __construct(object | array $original = [], ?Factory $validator = null)
     {
         if (!is_array($original) && !is_object($original)) {
             $type = gettype($original);


### PR DESCRIPTION
We originally had it annotated as stdClass but in fact it can and should alllow any object type (or array). This fixes an issue where OEM was passing it an alreadyt built ImmutableObject and it crashed saying it had to be an array or stdClass.
https://vicimus.atlassian.net/browse/BUMP-11986