### PR TITLE
dev(shared): fix a flaw in the interface

### DIFF
--- a/src/Interfaces/Store.php
+++ b/src/Interfaces/Store.php
@@ -37,6 +37,8 @@ interface Store
      * @param string|mixed $value
      *
      * @return mixed
+     *
+     * @phpcsSuppress SlevomatCodingStandard.TypeHints.ReturnTypeHint
      */
     public function setAttribute($key, $value);
 

--- a/src/Interfaces/Store.php
+++ b/src/Interfaces/Store.php
@@ -35,8 +35,10 @@ interface Store
      *
      * @param string|mixed $key
      * @param string|mixed $value
+     *
+     * @return mixed
      */
-    public function setAttribute($key, $value): void;
+    public function setAttribute($key, $value);
 
     /**
      * Convert the store into an array of data


### PR DESCRIPTION
Model.php and Store.php both had a setAttribute method but the return was different. Model one overrides Laravel, so that's the signature I went with and this should fix issues when upgrading packages that use these classes.
https://vicimus.atlassian.net/browse/BUMP-12102