### PR TITLE
dev(shared): support for http callbacks

### DIFF
--- a/src/Interfaces/Leads/Distribution.php
+++ b/src/Interfaces/Leads/Distribution.php
@@ -21,4 +21,9 @@ interface Distribution
      * @return string
      */
     public function getHttpVendorId(): string;
+
+    /**
+     * @return int
+     */
+    public function getStoreId(): int;
 }

--- a/src/Interfaces/Leads/HttpCallbackHandler.php
+++ b/src/Interfaces/Leads/HttpCallbackHandler.php
@@ -4,6 +4,9 @@ namespace Vicimus\Support\Interfaces\Leads;
 
 use Psr\Http\Message\ResponseInterface;
 
+/**
+ * An interface for Http callback Handlers related to leads, lead distributions and http adf content
+ */
 interface HttpCallbackHandler
 {
     /**

--- a/src/Interfaces/Leads/HttpCallbackHandler.php
+++ b/src/Interfaces/Leads/HttpCallbackHandler.php
@@ -1,0 +1,18 @@
+<?php declare(strict_types = 1);
+
+namespace Vicimus\Support\Interfaces\Leads;
+
+use Psr\Http\Message\ResponseInterface;
+
+interface HttpCallbackHandler
+{
+    /**
+     * Handle the response from the http post
+     *
+     * @param Distribution      $distribution The distribution that made the POST
+     * @param ResponseInterface $result       The response from the server
+     *
+     * @return void
+     */
+    public function handle(Distribution $distribution, ResponseInterface $result): void;
+}


### PR DESCRIPTION
When sending http leads, the distribution needs to be able to say what store id it is for.
https://vicimus.atlassian.net/browse/BUMP-12369