### PR TITLE
dev(shared): record interface change

### DIFF
--- a/src/Interfaces/MarketingSuite/Assets/Creatable.php
+++ b/src/Interfaces/MarketingSuite/Assets/Creatable.php
@@ -82,11 +82,11 @@ interface Creatable
      *
      * @param string               $property The property to set
      * @param string|int|bool|null $value    The value to save
-     * @param bool                 $hidden   The hidden state of a property
+     * @param int                  $hidden   The hidden state of a property
      *
      * @return void
      */
-    public function record(string $property, $value = null, bool $hidden = false): void;
+    public function record(string $property, $value = null, int $hidden = 0): void;
 
     /**
      * Record a property value, maintaining the old value if one exists.

--- a/src/Interfaces/MarketingSuite/Campaign.php
+++ b/src/Interfaces/MarketingSuite/Campaign.php
@@ -152,13 +152,13 @@ interface Campaign extends Eloquent
      *
      * @param string               $property The property to set
      * @param string|int|bool|null $value    If set, will record a property rather than get
-     * @param bool                 $hidden   The hidden state of a property
+     * @param int                  $hidden   The hidden state of a property
      *
      * @return void
      *
      * @throws JsonException
      */
-    public function record(string $property, $value = null, bool $hidden = false): void;
+    public function record(string $property, $value = null, int $hidden = 0): void;
 
     /**
      * A campaign can have one script

--- a/src/Interfaces/MarketingSuite/SimpleProperties.php
+++ b/src/Interfaces/MarketingSuite/SimpleProperties.php
@@ -22,9 +22,9 @@ interface SimpleProperties
      *
      * @param string $property The property to set
      * @param mixed  $value    If set, will record a property rather than get
-     * @param bool   $hidden   The hidden state of a property
+     * @param int    $hidden   The hidden state of a property
      *
      * @return void
      */
-    public function record(string $property, $value = null, bool $hidden = false): void;
+    public function record(string $property, $value = null, int $hidden = 0): void;
 }


### PR DESCRIPTION
The hidden field is stored as a 0 or 1, the true/false property here was causing unnecessary audits.
https://vicimus.atlassian.net/browse/BUMP-12501