### PR TITLE
dev(shared): source record has campaign

### DIFF
--- a/src/Interfaces/MarketingSuite/HasSource.php
+++ b/src/Interfaces/MarketingSuite/HasSource.php
@@ -53,6 +53,14 @@ interface HasSource
     public function contentId(): ?int;
 
     /**
+     *
+     * Retrieve the destination for the source placements
+     *
+     * i.e. Messenger/VDP/PURL
+     */
+    public function getDestination(): ?string;
+
+    /**
      * Retrieve the identifier of the has source instance
      */
     public function getId(): int;

--- a/src/Interfaces/MarketingSuite/SourceRecord.php
+++ b/src/Interfaces/MarketingSuite/SourceRecord.php
@@ -8,6 +8,7 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\MorphMany;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
 use Illuminate\Support\Collection;
+use Shared\Contracts\Audienceable;
 
 /**
  * @property Collection|Audience[] $audiences
@@ -25,6 +26,11 @@ interface SourceRecord
      * A source has many audiences assigned to it
      */
     public function audiences(): MorphMany;
+
+    /**
+     * Get the sources associated campaign
+     */
+    public function campaign(): HasSource;
 
     /**
      * A source can have many custom audiences

--- a/src/Interfaces/MarketingSuite/SourceRecord.php
+++ b/src/Interfaces/MarketingSuite/SourceRecord.php
@@ -8,7 +8,6 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\MorphMany;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
 use Illuminate\Support\Collection;
-use Shared\Contracts\Audienceable;
 
 /**
  * @property Collection|Audience[] $audiences


### PR DESCRIPTION
Adds a method to retrieve the associated campaign from a source record.
https://vicimus.atlassian.net/browse/BUMP-12874