### PR TITLE
dev(shared): deprecate custom datetime class

### DIFF
--- a/src/Classes/DateTime.php
+++ b/src/Classes/DateTime.php
@@ -7,6 +7,9 @@ namespace Vicimus\Support\Classes;
 use DateTime as Date;
 use DateTimeZone;
 
+/**
+ * @deprecated
+ */
 class DateTime extends Date
 {
     public function __construct(string $time = 'now', ?DateTimeZone $timezone = null)


### PR DESCRIPTION
We should be using Carbon, not this.
https://vicimus.atlassian.net/browse/BUMP-13091