### PR TITLE
feat: support per-process sqlite isolation via TEST_TOKEN for paratest

### DIFF
--- a/src/Testing/TestSqliteDatabase.php
+++ b/src/Testing/TestSqliteDatabase.php
@@ -50,6 +50,8 @@ trait TestSqliteDatabase
     {
         $external['null'] = '';
         $external = array_reverse($external);
+        $testToken = getenv('TEST_TOKEN');
+        $suffix = $testToken !== false ? '_' . $testToken : '';
 
         foreach ($external as $code => $database) {
             if ($database) {
@@ -58,10 +60,15 @@ trait TestSqliteDatabase
 
             $stub = sprintf('%s/%sstub.sqlite', $path, $database);
             $secondStub = sprintf('%s/%sunsullied.sqlite', $path, $database);
-            $test = sprintf('%s/%stesting.sqlite', $path, $database);
+            $test = sprintf('%s/%stesting%s.sqlite', $path, $database, $suffix);
             if ($database) {
                 config()->set('database.connections.' . $code . '.database', $test);
             } else {
+                $defaultConnection = config('database.default');
+                if ($defaultConnection) {
+                    config()->set('database.connections.' . $defaultConnection . '.database', $test);
+                }
+
                 foreach ($aliases as $alias) {
                     config()->set('database.connections.' . $alias . '.database', $test);
                     config()->set('database.connections.' . $alias . '.driver', 'sqlite');
@@ -80,7 +87,7 @@ trait TestSqliteDatabase
                 continue;
             }
 
-            $attachment = sprintf('attach \'%s/%stesting.sqlite\' as %s', database_path(), $database, $code);
+            $attachment = sprintf('attach \'%s\' as %s', $test, $code);
             DB::select($attachment);
 
             $this->attached[$database] = $code;
@@ -103,6 +110,32 @@ trait TestSqliteDatabase
      */
     private function doOneTimeSetup(?string $database, string $secondStub, string $stub): void
     {
+        $lockFile = $stub . '.lock';
+        $lock = fopen($lockFile, 'c');
+        if (!$lock) {
+            throw new RuntimeException('Unable to create lock file: ' . $lockFile);
+        }
+
+        flock($lock, LOCK_EX);
+
+        try {
+            $this->doOneTimeSetupWork($database, $secondStub, $stub);
+        } finally {
+            flock($lock, LOCK_UN);
+            fclose($lock);
+        }
+    }
+
+    /**
+     * @throws TestException
+     */
+    private function doOneTimeSetupWork(?string $database, string $secondStub, string $stub): void
+    {
+        if ($this->isSetupComplete($secondStub)) {
+            $GLOBALS['setupDatabase'] = !$database ? true : ($GLOBALS['setupDatabase'] ?? false);
+            return;
+        }
+
         $output = $this->initializeOutput();
         $bench = (new Benchmark())->init();
         if (!$this->isOutdated($database)) {
@@ -131,6 +164,18 @@ trait TestSqliteDatabase
         }
 
         $this->finish($database, $stub, $secondStub);
+    }
+
+    /**
+     * Check if setup was already completed by another process
+     */
+    private function isSetupComplete(string $secondStub): bool
+    {
+        if (getenv('TEST_TOKEN') === false) {
+            return false;
+        }
+
+        return file_exists($secondStub) && filesize($secondStub) > 0;
     }
 
     /**

--- a/src/Testing/TestSqliteDatabase.php
+++ b/src/Testing/TestSqliteDatabase.php
@@ -64,15 +64,7 @@ trait TestSqliteDatabase
             if ($database) {
                 config()->set('database.connections.' . $code . '.database', $test);
             } else {
-                $defaultConnection = config('database.default');
-                if ($defaultConnection) {
-                    config()->set('database.connections.' . $defaultConnection . '.database', $test);
-                }
-
-                foreach ($aliases as $alias) {
-                    config()->set('database.connections.' . $alias . '.database', $test);
-                    config()->set('database.connections.' . $alias . '.driver', 'sqlite');
-                }
+                $this->configureDefaultConnection($test, $aliases);
             }
 
             if (!($GLOBALS['setupDatabase'] ?? false)) {
@@ -95,6 +87,24 @@ trait TestSqliteDatabase
     }
 
     /**
+     * Configure the default database connection and aliases
+     *
+     * @param string[] $aliases
+     */
+    private function configureDefaultConnection(string $test, array $aliases): void
+    {
+        $defaultConnection = config('database.default');
+        if ($defaultConnection) {
+            config()->set('database.connections.' . $defaultConnection . '.database', $test);
+        }
+
+        foreach ($aliases as $alias) {
+            config()->set('database.connections.' . $alias . '.database', $test);
+            config()->set('database.connections.' . $alias . '.driver', 'sqlite');
+        }
+    }
+
+    /**
      * Execute the migration
      */
     protected function doMigration(): void
@@ -107,6 +117,7 @@ trait TestSqliteDatabase
      * Do the one time setup of the database
      *
      * @throws TestException
+     * @throws RuntimeException
      */
     private function doOneTimeSetup(?string $database, string $secondStub, string $stub): void
     {

--- a/tests/Unit/Testing/TestSqliteDatabaseTest.php
+++ b/tests/Unit/Testing/TestSqliteDatabaseTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Vicimus\Support\Tests\Unit\Testing;
 
+use Illuminate\Config\Repository;
 use Illuminate\Support\Facades\Facade;
 use org\bovigo\vfs\vfsStream;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -30,6 +31,8 @@ class TestSqliteDatabaseTest extends TestCase
         $app->bind('path.base', static fn () => __DIR__ . '/../../../resources/testing');
 
         $app->bind('path.database', static fn () => __DIR__ . '/../../../resources/testing');
+
+        $app->instance('config', new Repository());
 
         putenv('VICIMUS_TEST_NO_DATABASE_OUTPUT=1');
     }


### PR DESCRIPTION
When TEST_TOKEN env var is set (by paratest), suffix SQLite test database filenames (e.g. testing_1.sqlite, testing_2.sqlite) so parallel processes don't race on the same files.

No behavioral change when TEST_TOKEN is not set.