### PR TITLE
perf(shared): memoize getDates() on base model

### DIFF
--- a/src/Classes/APIExceptionHandler.php
+++ b/src/Classes/APIExceptionHandler.php
@@ -36,9 +36,9 @@ class APIExceptionHandler
 
         return response()->json([
             'error' => $exception->getMessage(),
-            'type'  => $exception::class,
-            'line'  => $exception->getLine(),
-            'file'  => $exception->getFile(),
+            'type' => $exception::class,
+            'line' => $exception->getLine(),
+            'file' => $exception->getFile(),
         ], $code);
     }
 }

--- a/src/Classes/Benchmark.php
+++ b/src/Classes/Benchmark.php
@@ -51,9 +51,9 @@ class Benchmark
         }
 
         return [
-            'time'   => $time,
+            'time' => $time,
             'memory' => $memory,
-            'peak'   => $peak,
+            'peak' => $peak,
             'customs' => $customs,
         ];
     }

--- a/src/Database/Model.php
+++ b/src/Database/Model.php
@@ -67,6 +67,13 @@ class Model extends LaravelModel
     private array $columns = [];
 
     /**
+     * Memoized result of getDates() for the life of the instance.
+     *
+     * @var string[]|null
+     */
+    private ?array $cachedDates = null;
+
+    /**
      * Respect no casts rule
      *
      * @phpcsSuppress SlevomatCodingStandard.TypeHints.DisallowMixedTypeHint
@@ -140,6 +147,17 @@ class Model extends LaravelModel
         }
 
         return $this->getRelationValue($key);
+    }
+
+    /**
+     * Get the attributes that should be converted to dates. Memoized for the
+     * life of the instance since the result is invariant at runtime.
+     *
+     * @return string[]
+     */
+    public function getDates(): array
+    {
+        return $this->cachedDates ??= parent::getDates();
     }
 
     /**


### PR DESCRIPTION
A Blackfire profile of a consuming application's vehicle listing page showed Eloquent's getDates() firing thousands of times per request, because the attribute-casting machinery calls it once per attribute read. The returned set of date columns is invariant for the life of a hydrated model instance, so recomputing it on every call is pure overhead.

This memoizes getDates() on the Vicimus base model: the first call delegates to the parent implementation and stores the result in a private cachedDates field, and subsequent calls return the cached array. Behaviour is unchanged, and the existing Database ModelTest passes on PHP 8.3 confirming the override is signature-compatible with the current Laravel base model.

Note for the glovebox bump: glovebox currently pins the v5 support line, so it will not pick this up until the Laravel 12 upgrade moves it onto v6. The dependency bump is therefore deferred to that upgrade rather than done now.

https://vicimus.atlassian.net/browse/GBX-7071