### PR TITLE
feat(lifecycle): add renderOem to PlaceholderData interface

### DIFF
--- a/src/Interfaces/MarketingSuite/Assets/PlaceholderData.php
+++ b/src/Interfaces/MarketingSuite/Assets/PlaceholderData.php
@@ -35,6 +35,12 @@ interface PlaceholderData
     public function oem(): OemService;
 
     /**
+     * The OEM slug to render styling with, resolved for the recipient (for
+     * example from the sold vehicle). Null falls back to the campaign OEM.
+     */
+    public function renderOem(): ?string;
+
+    /**
      * Get the store to use
      */
     public function store(): ?Store;


### PR DESCRIPTION
Adds renderOem(): ?string to the PlaceholderData interface so the render layer can resolve OEM styling ($logo, $oem-*) from a per-recipient OEM (for example the sold vehicle) instead of only the campaign OEM. Null falls back to the campaign OEM.

Part of the CSSR Welcome Package brand-from-vehicle work (BUMP-16177). Consumed by vicimus/assetbuilder and MarketingSuite PRs on the same branch.

https://vicimus.atlassian.net/browse/BUMP-16177